### PR TITLE
Enable incremental TeaVM compilation

### DIFF
--- a/src/main/kotlin/com/edibleday/TeaVMTask.kt
+++ b/src/main/kotlin/com/edibleday/TeaVMTask.kt
@@ -87,6 +87,7 @@ open class TeaVMTask : DefaultTask() {
         val cacheDirectory = File(project.buildDir, "teavm-cache")
         cacheDirectory.mkdirs()
         tool.cacheDirectory = cacheDirectory
+        tool.setIncremental(true)
         tool.runtime = runtime
         tool.isMinifying = minified
         tool.log = log


### PR DESCRIPTION
Previously, TeaVM compilation was never set to incremental. This
meant that TeaVM did not make any use of its cache to avoid recompiling
things that haven't changed.

This commit fixes it by always enabling incremental mode instead.